### PR TITLE
Added github container registry in pipeline

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       # 1) Check out your repository code with full depth
       - name: Checkout code
@@ -32,13 +35,23 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       
-      # 5) Log in to Docker Hub
+      # 5a) Log in to Docker Hub
       - name: Log in to Docker Hub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      
+      # 5b) Log in to GitHub Container Registry (GHCR)
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       
       # 6) Extract metadata (version, branch name, etc.)
       - name: Extract metadata
@@ -63,6 +76,8 @@ jobs:
           tags: |
             huntarr/huntarr:latest
             huntarr/huntarr:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/huntarr:latest
+            ghcr.io/${{ github.repository_owner }}/huntarr:${{ github.sha }}
       
       # 7b) Build & Push if on 'dev' branch
       - name: Build and Push (dev)
@@ -75,6 +90,8 @@ jobs:
           tags: |
             huntarr/huntarr:dev
             huntarr/huntarr:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/huntarr:dev
+            ghcr.io/${{ github.repository_owner }}/huntarr:${{ github.sha }}
       
       # 7c) Build & Push if it's a tag/release
       - name: Build and Push (release)
@@ -87,6 +104,8 @@ jobs:
           tags: |
             huntarr/huntarr:${{ steps.meta.outputs.VERSION }}
             huntarr/huntarr:latest
+            ghcr.io/${{ github.repository_owner }}/huntarr:${{ steps.meta.outputs.VERSION }}
+            ghcr.io/${{ github.repository_owner }}/huntarr:latest
       
       # 7d) Build & Push for any other branch
       - name: Build and Push (feature branch)
@@ -99,6 +118,8 @@ jobs:
           tags: |
             huntarr/huntarr:${{ steps.meta.outputs.BRANCH }}
             huntarr/huntarr:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/huntarr:${{ steps.meta.outputs.BRANCH }}
+            ghcr.io/${{ github.repository_owner }}/huntarr:${{ github.sha }}
       
       # 7e) Just build on pull requests
       - name: Build (PR)


### PR DESCRIPTION
Docker images will know be automatically published to ghrc and Dockerhub.

This pr adds permission to be able to write to the GitHub docker registry.
The settings of the repository may also need to be changed, look at: Settings -> Actions -> General -> "Workflow permissions" and ensure that "Read and write permissions" is selected.

addresses: https://github.com/plexguide/Huntarr.io/issues/289