### PR TITLE
Fix small miss in cycle-countdown.js

### DIFF
--- a/frontend/static/js/cycle-countdown.js
+++ b/frontend/static/js/cycle-countdown.js
@@ -95,7 +95,7 @@ window.CycleCountdown = (function() {
         isFetchingData = true;
         
         // Use a direct URL to the web-accessible version of sleep.json
-        const sleepJsonUrl = window.location.origin + './static/data/sleep.json';
+        const sleepJsonUrl = './static/data/sleep.json';
         
         // Add a timestamp to prevent caching
         const url = `${sleepJsonUrl}?t=${Date.now()}`;


### PR DESCRIPTION
Need to remove the leader ahead of the subpath as well. Missed this in last commit. Sorry.