### PR TITLE
Add configurable logging levels via LOG_LEVEL environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN mkdir -p /config && chmod -R 755 /config
 # Set environment variables
 ENV PYTHONPATH=/app
 ENV TZ=UTC
+ENV LOG_LEVEL=INFO
 # ENV APP_TYPE=sonarr # APP_TYPE is likely managed via config now, remove if not needed
 
 # Expose port

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     environment:
       - TZ=${TZ:-UTC}
       - BASE_URL=${BASE_URL:-}
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
     restart: unless-stopped
     # Graceful shutdown configuration
     stop_signal: SIGTERM

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -105,6 +105,7 @@
   -p 9705:9705 \
   -v /path/to/huntarr/config:/config \
   -e TZ=America/New_York \
+  -e LOG_LEVEL=INFO \
   huntarr/huntarr:latest</code></pre>
 
                         <div class="alert alert-warning">
@@ -325,11 +326,33 @@ services:
       - ./huntarr-config:/config
     environment:
       - TZ=America/New_York
+      - LOG_LEVEL=INFO
       - PUID=1000
       - PGID=1000</code></pre>
 
                         <strong>Run with:</strong>
                         <pre class="terminal"><code>docker-compose up -d</code></pre>
+                    </div>
+                </div>
+                
+                <div class="faq-item">
+                    <div class="faq-question">How do I enable debug logging for troubleshooting?</div>
+                    <div class="faq-answer">
+                        Set the LOG_LEVEL environment variable to DEBUG:
+                        
+                        <pre class="terminal"><code># For Docker run:
+docker run ... -e LOG_LEVEL=DEBUG huntarr/huntarr:latest
+
+# For docker-compose, add to environment section:
+environment:
+  - LOG_LEVEL=DEBUG
+  
+# Then restart the container:
+docker restart huntarr</code></pre>
+                        
+                        <div class="alert alert-info">
+                            <strong>Remember:</strong> Set LOG_LEVEL back to INFO after troubleshooting to reduce log verbosity.
+                        </div>
                     </div>
                 </div>
             </section>

--- a/docs/getting-started/installation.html
+++ b/docs/getting-started/installation.html
@@ -92,6 +92,7 @@
   -p 9705:9705 \
   -v /your-path/huntarr:/config \
   -e TZ=America/New_York \
+  -e LOG_LEVEL=INFO \
   huntarr/huntarr:latest</code></pre>
 
                     <h5><i class="fab fa-github" style="margin-right: 8px; color: #333;"></i>Option 2: GitHub Container Registry</h5>
@@ -100,6 +101,7 @@
   -p 9705:9705 \
   -v /your-path/huntarr:/config \
   -e TZ=America/New_York \
+  -e LOG_LEVEL=INFO \
   ghcr.io/plexguide/huntarr:latest</code></pre>
                     
                     <p>To check on the status of the program:</p>
@@ -119,7 +121,8 @@
     volumes:
       - /your-path/huntarr:/config
     environment:
-      - TZ=America/New_York</code></pre>
+      - TZ=America/New_York
+      - LOG_LEVEL=INFO</code></pre>
 
                     <h5><i class="fab fa-github" style="margin-right: 8px; color: #333;"></i>Option 2: GitHub Container Registry</h5>
                     <pre class="terminal"><code>services:
@@ -132,7 +135,8 @@
     volumes:
       - /your-path/huntarr:/config
     environment:
-      - TZ=America/New_York</code></pre>
+      - TZ=America/New_York
+      - LOG_LEVEL=INFO</code></pre>
                     
                     <p>Then run:</p>
                     <pre class="terminal"><code class="command-prompt">docker-compose up -d huntarr</code></pre>
@@ -182,6 +186,7 @@
   -p 9705:9705 \
   -v /mnt/user/appdata/huntarr:/config \
   -e TZ=America/New_York \
+  -e LOG_LEVEL=INFO \
   huntarr/huntarr:latest</code></pre>
 
                     <h5><i class="fab fa-github" style="margin-right: 8px; color: #333;"></i>GitHub Container Registry</h5>
@@ -190,6 +195,7 @@
   -p 9705:9705 \
   -v /mnt/user/appdata/huntarr:/config \
   -e TZ=America/New_York \
+  -e LOG_LEVEL=INFO \
   ghcr.io/plexguide/huntarr:latest</code></pre>
                 </div>
                 

--- a/docs/settings/settings.html
+++ b/docs/settings/settings.html
@@ -62,6 +62,7 @@
                             <li><a href="#debug-mode">Debug Mode</a></li>
                             <li><a href="#display-resources">Display Resources</a></li>
                             <li><a href="#low-usage-mode">Low Usage Mode</a></li>
+                            <li><a href="#log-level">Log Level Configuration</a></li>
                         </ul>
                     </li>
                     <li><a href="#notifications">Notifications</a>
@@ -172,6 +173,27 @@
                 </ul>
                 
                 <p>The setting takes effect immediately and doesn't require a restart. You can toggle it on and off as needed depending on your current usage requirements.</p>
+                
+                <h3 id="log-level"><a href="#log-level" class="info-icon"><i class="fas fa-info-circle"></i></a> Log Level Configuration</h3>
+                <p>Controls the verbosity of Huntarr's logging output through the LOG_LEVEL environment variable.</p>
+                
+                <p>Available log levels:</p>
+                <ul>
+                    <li><strong>DEBUG:</strong> Detailed information for troubleshooting issues</li>
+                    <li><strong>INFO:</strong> General information about operations (default)</li>
+                    <li><strong>WARNING:</strong> Important warnings that don't stop operation</li>
+                    <li><strong>ERROR:</strong> Error messages for serious issues</li>
+                    <li><strong>CRITICAL:</strong> Critical errors that may stop operation</li>
+                </ul>
+                
+                <p>Set this in your Docker environment:</p>
+                <pre><code>-e LOG_LEVEL=DEBUG</code></pre>
+                
+                <p>Or in docker-compose.yml:</p>
+                <pre><code>environment:
+  - LOG_LEVEL=DEBUG</code></pre>
+                
+                <p>Changes require a container restart to take effect. Use DEBUG level for troubleshooting, then return to INFO for normal operation to reduce log verbosity.</p>
             </section>
             
             <section id="notifications">

--- a/src/primary/settings_manager.py
+++ b/src/primary/settings_manager.py
@@ -13,7 +13,6 @@ import time
 from typing import Dict, Any, Optional, List
 
 # Create a simple logger for settings_manager
-logging.basicConfig(level=logging.INFO)
 settings_logger = logging.getLogger("settings_manager")
 
 # Database integration

--- a/src/primary/utils/logger.py
+++ b/src/primary/utils/logger.py
@@ -85,14 +85,34 @@ class LocalTimeFormatter(logging.Formatter):
                 
             return s
 
+def get_log_level():
+    """Get the logging level from LOG_LEVEL environment variable with fallback to INFO."""
+    # Check LOG_LEVEL environment variable
+    log_level_str = os.environ.get('LOG_LEVEL', '').upper()
+    if log_level_str in ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']:
+        return getattr(logging, log_level_str)
+        
+    # Default to INFO level
+    return logging.INFO
+
+def configure_root_logger():
+    """Configure root logger to respect LOG_LEVEL environment variable."""
+    root_logger = logging.getLogger()
+    log_level = get_log_level()
+    root_logger.setLevel(log_level)
+    
+    # Configure all existing handlers to use the new level
+    for handler in root_logger.handlers:
+        handler.setLevel(log_level)
+
 def setup_main_logger():
     """Set up the main Huntarr logger."""
     global logger
     log_name = "huntarr"
     log_file = MAIN_LOG_FILE
 
-    # Always use DEBUG level - let frontend filter what users see
-    use_log_level = logging.DEBUG
+    # Get log level from environment with INFO as default
+    use_log_level = get_log_level()
 
     # Get or create the main logger instance
     current_logger = logging.getLogger(log_name)
@@ -125,6 +145,10 @@ def setup_main_logger():
     current_logger.debug("Debug logging enabled for main logger")
 
     logger = current_logger # Assign to the global variable
+    
+    # Configure root logger to ensure all loggers respect LOG_LEVEL
+    configure_root_logger()
+    
     return current_logger
 
 def get_logger(app_type: str) -> logging.Logger:
@@ -158,8 +182,8 @@ def get_logger(app_type: str) -> logging.Logger:
     # Prevent propagation to the main 'huntarr' logger or root logger
     app_logger.propagate = False
     
-    # Always use DEBUG level - let frontend filter what users see
-    log_level = logging.DEBUG
+    # Get log level from environment with INFO as default
+    log_level = get_log_level()
         
     app_logger.setLevel(log_level)
     
@@ -197,11 +221,10 @@ def get_logger(app_type: str) -> logging.Logger:
 
 def update_logging_levels():
     """
-    Update all logger levels to DEBUG level.
-    This function is kept for compatibility but now always sets DEBUG level.
+    Update all logger levels based on environment configuration.
     """
-    # Always use DEBUG level - let frontend filter what users see
-    level = logging.DEBUG
+    # Get log level from environment
+    level = get_log_level()
     
     # Set level for main logger
     if logger:


### PR DESCRIPTION
## Summary
Adds configurable logging levels to reduce log noise in container deployments.
Issue: https://github.com/plexguide/Huntarr.io/issues/568

## Changes
- Add LOG_LEVEL environment variable support
- Configure all loggers to respect the log level
- Change default from DEBUG to INFO level
- Update Docker configuration
- Update documentation

## Testing
### Python Syntax & Import Tests
- Both modified Python files (`settings_manager.py`, `logger.py`) compile without syntax errors
- New logging functions (`get_log_level()`, `configure_root_logger()`) are properly defined and callable
- Environment variable handling works correctly:
  - `LOG_LEVEL=DEBUG` → returns 10 (DEBUG level)
  - Default when not set → returns 20 (INFO level)

### Docker Integration Tests
- Docker build completes successfully with new environment variable
- `ENV LOG_LEVEL=INFO` properly set as default in Dockerfile
- `LOG_LEVEL=${LOG_LEVEL:-INFO}` works correctly in docker-compose.yml
- Container environment variable handling:
  - Default: `LOG_LEVEL=INFO` in container
  - Override: `-e LOG_LEVEL=WARNING` properly overrides to WARNING

### Environment Variable Validation
- **Default behavior**: LOG_LEVEL defaults to INFO when environment variable not set
- **Override behavior**: Environment variable properly overrides default value
- **Container integration**: Both default and runtime override scenarios work correctly

## Breaking Changes
None - fully backward compatible.